### PR TITLE
Code updated to use gpt-3.5-turbo 

### DIFF
--- a/pages/api/util.ts
+++ b/pages/api/util.ts
@@ -11,7 +11,12 @@ Follow Up Input: {question}
 Standalone question:`);
 
 const QA_PROMPT = PromptTemplate.fromTemplate(
-  `You are an AI assistant for a consulting firm.
+  `You are an AI assistant for the open source library LangChain. The documentation is located at https://langchain.readthedocs.io.
+You are given the following extracted parts of a long document and a question. Provide a conversational answer with a hyperlink to the documentation.
+You should only use hyperlinks that are explicitly listed as a source in the context. Do NOT make up a hyperlink that is not listed.
+If the question includes a request for code, provide a code block directly from the documentation.
+If you don't know the answer, just say "Hmm, I'm not sure." Don't try to make up an answer.
+If the question is not about LangChain, politely inform them that you are tuned to only answer questions about LangChain.
 Question: {question}
 =========
 {context}

--- a/pages/api/util.ts
+++ b/pages/api/util.ts
@@ -1,4 +1,4 @@
-import { OpenAI } from "langchain/llms";
+import { OpenAIChat } from "langchain/llms";
 import { LLMChain, ChatVectorDBQAChain, loadQAChain } from "langchain/chains";
 import { HNSWLib } from "langchain/vectorstores";
 import { PromptTemplate } from "langchain/prompts";
@@ -11,12 +11,7 @@ Follow Up Input: {question}
 Standalone question:`);
 
 const QA_PROMPT = PromptTemplate.fromTemplate(
-  `You are an AI assistant for the open source library LangChain. The documentation is located at https://langchain.readthedocs.io.
-You are given the following extracted parts of a long document and a question. Provide a conversational answer with a hyperlink to the documentation.
-You should only use hyperlinks that are explicitly listed as a source in the context. Do NOT make up a hyperlink that is not listed.
-If the question includes a request for code, provide a code block directly from the documentation.
-If you don't know the answer, just say "Hmm, I'm not sure." Don't try to make up an answer.
-If the question is not about LangChain, politely inform them that you are tuned to only answer questions about LangChain.
+  `You are an AI assistant for a consulting firm.
 Question: {question}
 =========
 {context}
@@ -25,11 +20,12 @@ Answer in Markdown:`);
 
 export const makeChain = (vectorstore: HNSWLib, onTokenStream?: (token: string) => void) => {
   const questionGenerator = new LLMChain({
-    llm: new OpenAI({ temperature: 0 }),
+    llm: new OpenAIChat({ temperature: 0,modelName: "gpt-3.5-turbo" }),
     prompt: CONDENSE_PROMPT,
   });
   const docChain = loadQAChain(
-    new OpenAI({
+    new OpenAIChat({
+      modelName: "gpt-3.5-turbo",
       temperature: 0,
       streaming: Boolean(onTokenStream),
       callbackManager: {


### PR DESCRIPTION
This update does not use any of the new features of the gpt-3.5-turbo (prefix) but can be used to train data and chat cheaper than before.